### PR TITLE
Allow disabling contiguous mode

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -1655,7 +1655,7 @@ class TiffWriter:
                 return 'I'
             return 'Q'
 
-        contiguous = not compress
+        contiguous = contiguous and not compress
         if tile:
             # one chunk per tile per plane
             if len(tile) == 2:


### PR DESCRIPTION
`imwrite` has a `contiguous` argument but its value is accidentally ignored. This change allows it to function as intended. Helps with one problem identified in #3.