### PR TITLE
Fix for Python 3.9/3.10: Replace deprecated cElementTree

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -2739,7 +2739,7 @@ class TiffFile:
 
     def _series_ome(self):
         """Return image series in OME-TIFF file(s)."""
-        from xml.etree import cElementTree as etree  # delayed import
+        from xml.etree import ElementTree as etree  # delayed import
         omexml = self.pages[0].description
         try:
             root = etree.fromstring(omexml)
@@ -10513,7 +10513,7 @@ def metaseries_description_metadata(description):
     if not description.startswith('<MetaData>'):
         raise ValueError('invalid MetaSeries image description')
 
-    from xml.etree import cElementTree as etree  # delayed import
+    from xml.etree import ElementTree as etree  # delayed import
 
     root = etree.fromstring(description)
     types = {
@@ -11717,7 +11717,7 @@ def xml2dict(xml, sanitize=True, prefix=None):
     {'level1': {'level2': 3.5322}}
 
     """
-    from xml.etree import cElementTree as etree  # delayed import
+    from xml.etree import ElementTree as etree  # delayed import
 
     at = tx = ''
     if prefix:


### PR DESCRIPTION
`xml.etree.cElementTree` has been deprecated since Python 3.3 and will be removed in Python 3.9 or Python 3.10 (https://github.com/python/cpython/pull/19921).

Since Python 3.3, `xml.etree.ElementTree` will use a fast implementation whenever available.

* https://docs.python.org/3/library/xml.etree.elementtree.html
