### PR TITLE
Aperio SVS Support

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -2008,11 +2008,6 @@ class TiffWriter:
                 **self._metadata,
             )
             description += '\x00' * 64  # add buffer for in-place update
-        elif self._svs:
-            # This branch of the if statment is deliberately placed here
-            # to prevent description from being overwritten in the final
-            # "else" branch below.
-            pass
         elif metadata or metadata == {}:
             if self._truncate:
                 self._metadata.update(truncated=True)
@@ -2025,7 +2020,7 @@ class TiffWriter:
 
         if description is not None:
             description = description.encode('ascii')
-            addtag(270, 2, 0, description, writeonce=True and not self._svs)
+            addtag(270, 2, 0, description, writeonce=True)
         del description
 
         if software is None:

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -1026,6 +1026,7 @@ class TiffWriter:
             If True, write an Aperio format compatible file. This will
             overwrite the description parameter to add metadata that can be
             read by OpenSlide.
+
         """
         if append:
             # determine if file is an existing TIFF file that can be extended
@@ -2008,6 +2009,9 @@ class TiffWriter:
             )
             description += '\x00' * 64  # add buffer for in-place update
         elif self._svs:
+            # This branch of the if statment is deliberately placed here
+            # to prevent description from being overwritten in the final
+            # "else" branch below.
             pass
         elif metadata or metadata == {}:
             if self._truncate:

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -2756,8 +2756,6 @@ class TiffWriter:
                     **self._metadata,
                 )
             description = self._ome.tostring(declaration=True)
-        elif self._svs:
-            description = "Aperio Image Library v11.0.37"
         elif self._datashape[0] == 1:
             # description already up-to-date
             self._descriptiontag = None


### PR DESCRIPTION
@cgohlke Thank you for such a useful library. I found that I needed to modify `tifffile` to properly write Aperio SVS files. This pull request add support for writing Aperio SVS files that appear to be compatible with other tools such as QuPath.

The first major change is the addition of an optional `svs` parameter to `TiffWriter`. When this is specified, it allows `ImageDescription` to be written for each page of tags, which appears to be necessary to allow other libraries such as `openslide` to detect the organization of downsampled images.

To write an Aperio compatible SVS file, the user can write code similar to:

```python
magnification = 20
mpp = 0.25

options = {
    "compression": "jpeg",
    "photometric": "RGB",
    "software": "aperio",
}

with tifffile.TiffWriter(file, svs=True) as tif:
    # Write the full resolution image
    tif.write(im, 
              tile=(256,256), 
              description=f"Aperio Image Library vX.Y.Z\r\n{im.shape[0]}x{im.shape[1]} (256,256)|AppMag = {magnification}|MPP = {mpp}", 
              resolution=(mpp,mpp, "INCH"), 
              **options)

    # Write thumbnail
    tif.write(thumbnail, 
              description=f"Aperio Image Library vX.Y.Z\r\n{im.shape[0]}x{im.shape[1]} -> {thumbnail.shape[0]}x{thumbnail.shape[1]}|AppMag = {magnification}|MPP = {mpp}",
              rowsperstrip=16,
              **options)

    # Write downsampled images
    for d in [4,16]:
        dsim = im[::d, ::d, :]
        tif.write(dsim, 
                  tile=(256,256), 
                  description=f"Aperio Image Library vX.Y.Z\r\n{im.shape[0]}x{im.shape[1]} (256,256) -> {dsim.shape[0]}x{dsim.shape[1]}", 
                  resolution=(mpp,mpp, "INCH"), 
                  **options)

    # Write any label images...
        
```

As a side effect of development, `svs_metadata` was added which pulls metadata for the SVS and stores it in a dictionary with the following format:

```
{
    "Image": {
        0: {  # Full resolution metadata
            "NewSubfileType": str,
            "ImageWidth": int,
            "ImageLength": int,
            "BitsPerSample": (int, int, int),
            "Compression": COMPRESSION,
            "PhotometricInterpretation": PHOTOMETRIC,
            "ImageDescription": str,
            "SamplesPerPixel": int,
            "PlanarConfiguration": PLANARCONFIG,
            "TileWidth": int,
            "TileLength": int,
            "YCbCrSubSampling": (int, int),
            "ImageDepth": int,
            "Downsample": int,
        },
        1: {...}, # First downsampled metadata
        ...
    },
    "Thumbnail": {...}, # Thumbnail metadata
    ... # Other image metadata
}
```

I would love any feedback you might have.