### PR TITLE
fix svs_description_metadata for svss with double header

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -14545,7 +14545,7 @@ def svs_description_metadata(description):
     if not description.startswith('Aperio '):
         raise ValueError('invalid Aperio image description')
     result = {}
-    lines = description.split('\n')
+    lines = description.split('\n', 1)
     key, value = lines[0].strip().rsplit(None, 1)  # 'Aperio Image Library'
     result[key.strip()] = value.strip()
     if len(lines) == 1:


### PR DESCRIPTION
Hello @cgohlke,

I encountered an Aperio SVS that contains two different 'Aperio Image Library' headers in the description field.
Given the tile sizes in the actual svs the first header seems to be the correct one.

```
'Aperio Image Library v12.1.3 \r\n131472x94796 (256x256) J2K/KDU Q=70;Aperio Image Library v12.0.11 \r\n134112x94896 [0,100 131472x94796] (240x240) JPEG/RGB Q=70'|AppMag = 40|StripeWidth = 2032' ...
```

This PR allows to still parse the description metadata if for some reason there are multiple Aperio headers in the image description.

I can also add a test to the test suite if needed.

Cheers,
Andreas