### PR TITLE
bugfix: opening MicroManager OME.TIF files crashed

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -5924,7 +5924,7 @@ class TiffPage:
             setattr(self, name, value)
 
         value = tags.valueof(270, index=1)
-        if value:
+        if isinstance(value, str):
             self.description1 = value
 
         if self.subfiletype == 0:


### PR DESCRIPTION
Hi Christoph @cgohlke ,

your suggestion in #112 worked indeed! I can open my files now. Thanks for the hint!

Best,
Robert