### PR TITLE
Incorrect calculating channel count in scanimage

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -3893,7 +3893,7 @@ class TiffFile:
                     channels = len(channels)
                 except TypeError:
                     # channelSave is an int
-                    channels = int(channels)
+                    channels = 1
                 # slices = framedata.get(
                 #    'SI.hStackManager.actualNumSlices',
                 #     framedata.get('SI.hStackManager.numSlices', None),


### PR DESCRIPTION
Scanimage (tested on 2021 and 2018b) saves the channel count in the "SI.hChannels.channelSave" metadata key as follows:

- If there is one channel, save the ID of the channel
- If there is more than one channel, save a list of the channel IDs

Currently, detection of channel count is implemented as follows:

- If channels is a list, the number of channels is the length of the list
- If channels is an int, the number of channels is the value of the integer

If only one channel was recorded, but that channel was not channel ID 1, the current code incorrectly detects the channel count and incorrectly sorts the tiff by channel.  This PR fixes the issue.