### PR TITLE
Fix fei_metadata for HELIOS FIB-SEM tiff images

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -5811,7 +5811,16 @@ class TiffFile:
         if not self.is_fei:
             return None
         tags = self.pages.first.tags
-        return tags.valueof(34680, tags.valueof(34682))  # FEI_SFEG, FEI_HELIOS
+        result = {}
+        try:
+            result.update(tags.valueof(34680))  # FEI_SFEG
+        except Exception:
+            pass
+        try:
+            result.update(tags.valueof(34682))  # FEI_HELIOS
+        except Exception:
+            pass
+        return result
 
     @property
     def sem_metadata(self) -> dict[str, Any] | None:


### PR DESCRIPTION
I have FIBSEM images where the metadata is not being parsed correctly by tifffile.

Based on how the other metadata functions work (in particular, the sis_metadata function) I believe this line was intended to combine the two dictionary results:
https://github.com/cgohlke/tifffile/blob/375d97f62df6482142b51f1b38a49bdd24d18a60/tifffile/tifffile.py#L5814

However in practice, python will only ever return the values from the first dictionary (the FEI_SFEG metadata). 

When I open a HELIOS tiff image, I get an empty dictionary back instead of the real metadata. 

```python
from tifffile import TiffFile
tif = TiffFile(filename)
tif.fei_metadata  # unexpectedly returns an empty dictionary, instead of the real metadata values
```

This pull request modifies the code to combine the python dictionaries using the dictionary `.update()` method, using the same pattern as the existing tifffile function `sis_metadata`.