### PR TITLE
add label subfiletype check for svs series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio
+.vs
+*.pyproj
+*.sln

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -4864,6 +4864,8 @@ class TiffFile:
             if index == len(self.pages):
                 break
             page = self.pages[index]
+            if name == 'Label' and page.subfiletype == 9:
+                name = 'Macro'
             series.append(
                 TiffPageSeries(
                     [page],


### PR DESCRIPTION
I am working with svs files which have the labels removed. When the series was generated for these files, it was naming the macro level "Label". I added a statement to check whether the subfiletype matched correctly. If not, it changes it to "Macro" and will break on the next iteration because it is the last page.