### PR TITLE
Allow Adding "FillOrder" Tag to File

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -17174,7 +17174,6 @@ class _TIFF:
                 258,  # BitsPerSample
                 259,  # Compression
                 262,  # PhotometricInterpretation
-                266,  # FillOrder
                 273,  # StripOffsets
                 277,  # SamplesPerPixel
                 278,  # RowsPerStrip


### PR DESCRIPTION
At the moment it's not allowed to add the tag 266 ("FillOrder") to the tiff file output. When you add a related tuple (e.g. `(TIFF.TAGS.get("FillOrder"), TIFF.DATATYPES.SHORT, 1, TIFF.FILLORDER.MSB2LSB, True)` to the argument `extratags` of the `imwrite` function, this entry will be ignored because 266 is part of `TIFF.TAG_FILTERED` (see also line 2978).

I tested it locally: I removed 266 from that list and it works for me. Is there a reason because it's part of `TIFF.TAG_FILTERED`? Otherwise please remove. Thx! :)