### PR TITLE
Add missing SKIP_PRIVATE for test_issue_invalid_predictor

### DIFF
--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -2541,6 +2541,7 @@ def test_issue_extratags_filter(caplog):
             assert tags[266].value == 1
 
 
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_issue_invalid_predictor(caplog):
     """Test decoding JPEG compression with invalid predictor tag."""
     fname = private_file('issues/invalid_predictor.tiff')


### PR DESCRIPTION
Skip test_issue_invalid_predictor if SKIP_PRIVATE.  The test references private_file(), so it fails when run on top of checkout.