### PR TITLE
Ensure that if the previously opened file mode is retained if 'x'

### DIFF
--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -5334,15 +5334,16 @@ def test_filehandle_fsspec_http():
 def test_filehandle_exclusive_creation():
     """Test FileHandle with exclusive creation mode 'x'."""
     # https://github.com/cgohlke/tifffile/issues/221
+    image = numpy.zeros((128, 128, 3), dtype='uint8')
     with TempFileName('test_FileHandle_exclusive', ext='.bin') as fname:
         if os.path.exists(fname):
             os.remove(fname)
-        with FileHandle(fname, mode='x'):
-            pass
+        with FileHandle(fname, mode='x') as f:
+            with TiffWriter(f) as tif:
+                tif.write(image)
         with pytest.raises(FileExistsError):
             with FileHandle(fname, mode='x'):
                 pass
-
 
 ###############################################################################
 

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -14091,9 +14091,12 @@ class FileHandle:
             mode += 'b'  # type: ignore
         if mode not in {'rb', 'r+b', 'wb', 'xb'}:
             raise ValueError(f'invalid mode {mode}')
-        self._mode = mode
         self._fh = None
         self._file = file  # reference to original argument for re-opening
+        if isinstance(self._file, FileHandle):
+            self._mode = self._file._mode
+        else:
+            self._mode = mode
         self._name = name if name else ''
         self._dir = ''
         self._offset = -1 if offset is None else offset


### PR DESCRIPTION
this should pass but I don't think it does in the current version 2023.08.25
```python
@pytest.mark.parametrize('mode', ['wb', 'xb'])
def test_opening_mode(mode):
    image = np.zeros((128, 128, 3), dtype='uint8')
    with tifffile.FileHandle(filename, mode=mode) as f:
        with tifffile.TiffWriter(f) as tif_w:
            tif_w.write(image)
```

```
~/mambaforge/envs/dev/lib/python3.11/site-packages/tifffile/tifffile.py in ?(self, file, mode, name, offset, size)
  14099         self._offset = -1 if offset is None else offset
  14100         self._size = -1 if size is None else size
  14101         self._close = True
  14102         self._lock = NullContext()
> 14103         self.open()
  14104         assert self._fh is not None

~/mambaforge/envs/dev/lib/python3.11/site-packages/tifffile/tifffile.py in ?(self)
  14132                     self._name = f'{name}@{self._offset}{ext}'
  14133                 else:
  14134                     self._name = self._file._name
  14135             if self._mode and self._mode != self._file._mode:
> 14136                 raise ValueError(
  14137                     'FileHandle has wrong mode '
  14138                     f'{self._mode!r} != {self._file._mode!r}'
  14139                 )

ValueError: FileHandle has wrong mode 'wb' != 'xb'
```