### PR TITLE
Add missing pytest.mark.skipif

### DIFF
--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -2792,6 +2792,7 @@ def test_issue_non_volumetric():
             assert page.shape == data.shape
 
 
+@pytest.mark.skipif(SKIP_ZARR, reason=REASON)
 def test_issue_trucated_tileoffsets():
     """Test reading truncated tile offsets and bytecounts."""
     # https://github.com/cgohlke/tifffile/issues/227


### PR DESCRIPTION
This probably was forgotten when the test was added. Without it, the test fails [when running autopkgtest on Debian](https://salsa.debian.org/python-team/packages/tifffile/-/jobs/4745180).