### PR TITLE
Relax bitspersample checks

### DIFF
--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -452,6 +452,28 @@ numpy.set_printoptions(suppress=True, precision=5)
 
 # Tests for specific issues
 
+@pytest.mark.parametrize('bitspersample,dtype', [(6, "uint8"), (14, "uint16")])
+def test_issue_preencoded_tiles(bitspersample, dtype):
+    """Test writing pre-encoded tiles.
+
+    Use-case: Pre-encoded Lossless JPEG tiles
+    of various bit-depths (2--16).
+    """
+    buf = BytesIO()
+    dummy_tile = b'aabb'
+    imwrite(
+        buf,
+        iter((dummy_tile,)),
+        compression='jpeg',
+        shape=(1088, 1920),
+        tile=(1088, 1920),
+        dtype=dtype,
+        bitspersample=bitspersample,
+    )
+    buf.seek(0)
+    tiff_encoded = buf.read()
+    assert dummy_tile in tiff_encoded
+
 
 def test_issue_star_import():
     """Test from tifffile import *."""
@@ -3136,7 +3158,7 @@ class TestExceptions:
     def test_bitspersample_jpeg(self, fname):
         # invalid bitspersample for jpeg
         with pytest.raises(ValueError):
-            imwrite(fname, self.data, compression='jpeg', bitspersample=13)
+            imwrite(fname, self.data, compression='jpeg', bitspersample=17)
 
     def test_datetime(self, fname):
         # invalid datetime
@@ -15332,7 +15354,7 @@ def test_write_bitspersample_fail():
             with pytest.raises(ValueError):
                 tif.write(
                     data.astype(numpy.uint8),
-                    bitspersample=4,
+                    bitspersample=9,
                     compression=COMPRESSION.ADOBE_DEFLATE,
                     photometric=PHOTOMETRIC.RGB,
                 )

--- a/tests/test_tifffile.py
+++ b/tests/test_tifffile.py
@@ -452,28 +452,6 @@ numpy.set_printoptions(suppress=True, precision=5)
 
 # Tests for specific issues
 
-@pytest.mark.parametrize('bitspersample,dtype', [(6, "uint8"), (14, "uint16")])
-def test_issue_preencoded_tiles(bitspersample, dtype):
-    """Test writing pre-encoded tiles.
-
-    Use-case: Pre-encoded Lossless JPEG tiles
-    of various bit-depths (2--16).
-    """
-    buf = BytesIO()
-    dummy_tile = b'aabb'
-    imwrite(
-        buf,
-        iter((dummy_tile,)),
-        compression='jpeg',
-        shape=(1088, 1920),
-        tile=(1088, 1920),
-        dtype=dtype,
-        bitspersample=bitspersample,
-    )
-    buf.seek(0)
-    tiff_encoded = buf.read()
-    assert dummy_tile in tiff_encoded
-
 
 def test_issue_star_import():
     """Test from tifffile import *."""
@@ -15354,7 +15332,7 @@ def test_write_bitspersample_fail():
             with pytest.raises(ValueError):
                 tif.write(
                     data.astype(numpy.uint8),
-                    bitspersample=9,
+                    bitspersample=4,
                     compression=COMPRESSION.ADOBE_DEFLATE,
                     photometric=PHOTOMETRIC.RGB,
                 )

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -2777,12 +2777,13 @@ class TiffWriter:
             if bitspersample is not None and bitspersample != 1:
                 raise ValueError(f'{bitspersample=} must be 1 for bilevel')
             bitspersample = 1
-        elif compressiontag == 7 and datadtype == 'uint16':
+        elif compressiontag in {6, 7, 34892, 33007}:
+            # JPEG
             if bitspersample is None:
-                bitspersample = 12  # use 12-bit JPEG compression
-            elif not (9 <= bitspersample <= 16):
+                bitspersample = 12 if datadtype == 'uint16' else 8
+            if not 2 <= bitspersample <= 16:
                 raise ValueError(
-                    f'{bitspersample=} is not valid for JPEG compressed uint16'
+                    f'{bitspersample=} invalid for JPEG compression'
                 )
         elif bitspersample is None:
             bitspersample = datadtype.itemsize * 8
@@ -2796,7 +2797,7 @@ class TiffWriter:
         ):
             raise ValueError(f'{bitspersample=} out of range of {datadtype=}')
         elif compression:
-            if bitspersample > datadtype.itemsize * 8:
+            if bitspersample != datadtype.itemsize * 8:
                 raise ValueError(
                     f'{bitspersample=} cannot be used with compression'
                 )

--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -2778,11 +2778,12 @@ class TiffWriter:
                 raise ValueError(f'{bitspersample=} must be 1 for bilevel')
             bitspersample = 1
         elif compressiontag == 7 and datadtype == 'uint16':
-            if bitspersample is not None and bitspersample != 12:
+            if bitspersample is None:
+                bitspersample = 12  # use 12-bit JPEG compression
+            elif not (9 <= bitspersample <= 16):
                 raise ValueError(
-                    f'{bitspersample=} must be 12 for JPEG compressed uint16'
+                    f'{bitspersample=} is not valid for JPEG compressed uint16'
                 )
-            bitspersample = 12  # use 12-bit JPEG compression
         elif bitspersample is None:
             bitspersample = datadtype.itemsize * 8
         elif (
@@ -2795,7 +2796,7 @@ class TiffWriter:
         ):
             raise ValueError(f'{bitspersample=} out of range of {datadtype=}')
         elif compression:
-            if bitspersample != datadtype.itemsize * 8:
+            if bitspersample > datadtype.itemsize * 8:
                 raise ValueError(
                     f'{bitspersample=} cannot be used with compression'
                 )


### PR DESCRIPTION
The use-case I'm trying to fix here is to make it possible to write pre-encoded Lossless JPEG encoded tiles with all valid values of bitspersample ([2, 16]).