### PR TITLE
Declare build-system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools"]


### PR DESCRIPTION
Instead of implicitly falling back to legacy `setuptools.build_meta:__legacy__` backend. See [Writing your `pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#writing-your-pyproject-toml)