### PR TITLE
Add GitHub workflow to publish package on release with trusted publishing

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tifffile
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    - name: Build package
+      run: |
+        python -m build --outdir dist/ .
+    # - name: Install package
+    #   run: python -m pip install dist/*.whl 'tifffile[test]'
+    # - name: Run unit-tests
+    #   run: |
+    #     python -m pytest -vvra
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true


### PR DESCRIPTION
Trusted publishing (with attestations) means I can know for certain that what I download from PyPI is the same artefact which was generated in GitHub CI, meaning that what I see in GitHub is the same as what is installed - handy for auditing (rather than having to manually review all of the installed files on each release).

See [Python packaging documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing) and [pypi-publish GitHub action documentation](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) on trusted publishing - you'll need to configure an environment in PyPI and GitHub.

I've left out the package install and test steps as you've indicated in #157 that you don't want to run tests in CI.