### PR TITLE
Fix incorrect tags created by Philips DP v1.1

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -7721,6 +7721,11 @@ class TiffPage:
         elif self.is_vista or (self.index != 0 and self.parent.is_vista):
             # ISS Vista writes wrong ImageDepth tag
             self.imagedepth = 1
+        
+        elif self.is_philips or (self.index != 0 and self.parent.is_philips):
+            # Philips (DP v1.1) writes wrong ImageDepth and TileDepth tags
+            self.imagedepth = 1
+            self.tiledepth = 1
 
         elif self.is_stk:
             # read UIC1tag again now that plane count is known


### PR DESCRIPTION
It looks like a newer version of the Philips TIFF export (DP 1.1) is adding incorrect ImageDepth and TileDepth tags (that indicate the number of levels in the image pyramid).  Here's metadata from a recent Philips TIFF export.

```sh
tiffdump philips.tiff | grep -e ImageDepth -e TileDepth -e Directory \
-e Software | sed 's/Directory/\nDirectory/'
```

```
Directory 0: offset 109729104 (0x68a5550) next 141177672 (0x86a3348)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 1: offset 141177672 (0x86a3348) next 150466688 (0x8f7f080)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 2: offset 150466688 (0x8f7f080) next 153210202 (0x921cd5a)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 3: offset 153210202 (0x921cd5a) next 153958430 (0x92d381e)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 4: offset 153958430 (0x92d381e) next 154169666 (0x9307142)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 5: offset 154169666 (0x9307142) next 154224560 (0x93147b0)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 6: offset 154224560 (0x93147b0) next 154243918 (0x931934e)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 7: offset 154243918 (0x931934e) next 154250732 (0x931adec)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 8: offset 154250732 (0x931adec) next 154323220 (0x932c914)
Software (305) ASCII (2) 16<Philips DP v1.1\0>
ImageDepth (Silicon Graphics) (32997) LONG (4) 1<9>
TileDepth (Silicon Graphics) (32998) LONG (4) 1<9>

Directory 9: offset 154323220 (0x932c914) next 154391016 (0x933d1e8)

Directory 10: offset 154391016 (0x933d1e8) next 0 (0)
```