### PR TITLE
Fix packints_encode arguments

### DIFF
--- a/tifffile/_imagecodecs.py
+++ b/tifffile/_imagecodecs.py
@@ -551,8 +551,9 @@ def packints_encode(
     bitspersample: int,
     /,
     *,
-    axis: int = -1,
-    out: Any = None,
+    bitorder: Literal['>', '<'] | None = None,
+    runlen: int = 0,
+    out: int | byterarray | None  = None,
 ) -> bytes | bytearray:
     """Tightly pack integers.
 


### PR DESCRIPTION
The stub for packints_encode does not have the same type signature as the one in the imagecodecs library. This results in a confusing TypeError instead of the expected NotImplementedError. Fix the type signature so the correct error is raised.

Closes: #320